### PR TITLE
ES2015ify and support Node.js >=4

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,3 @@ insert_final_newline = true
 [{package.json,*.yml}]
 indent_style = space
 indent_size = 2
-
-[*.md]
-trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto
+*.js text eol=lf

--- a/index.js
+++ b/index.js
@@ -1,15 +1,10 @@
 'use strict';
-var execFile = require('child_process').execFile;
-var Promise = require('pinkie-promise');
-var pify = require('pify');
+const execa = require('execa');
 
-module.exports = function (str) {
+module.exports = str => {
 	if (process.platform !== 'darwin') {
 		return Promise.reject(new Error('Only OS X systems are supported'));
 	}
 
-	return pify(execFile, Promise)('osascript', ['-e', str])
-		.then(function (stdout) {
-			return stdout.trim();
-		});
+	return execa('osascript', ['-e', str]).then(res => res.stdout);
 };

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const execa = require('execa');
 
 module.exports = str => {
 	if (process.platform !== 'darwin') {
-		return Promise.reject(new Error('Only OS X systems are supported'));
+		return Promise.reject(new Error('Only OS X is supported'));
 	}
 
 	return execa('osascript', ['-e', str]).then(res => res.stdout);

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "sindresorhus.com"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=4"
   },
   "scripts": {
     "test": "xo && ava"
@@ -27,11 +27,13 @@
     "execute"
   ],
   "dependencies": {
-    "pify": "^2.2.0",
-    "pinkie-promise": "^2.0.0"
+    "execa": "^0.3.0"
   },
   "devDependencies": {
     "ava": "*",
     "xo": "*"
+  },
+  "xo": {
+    "esnext": true
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -24,4 +24,4 @@ runApplescript('return "unicorn"').then(result => {
 
 ## License
 
-MIT © [Sindre Sorhus](http://sindresorhus.com)
+MIT © [Sindre Sorhus](https://sindresorhus.com)


### PR DESCRIPTION
Uses `execa` instead of `execFile` which allows us to remove `pify`.
