### PR TITLE
Specify operating system compatibility in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "email": "sindresorhus@gmail.com",
     "url": "sindresorhus.com"
   },
+  "os": [
+    "darwin"
+  ],
   "engines": {
     "node": ">=4"
   },


### PR DESCRIPTION
Since this package only runs on macOS, I’ve added the [`os` property](https://docs.npmjs.com/files/package.json#os) to `package.json`.