### PR TITLE
Update execa dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "execute"
   ],
   "dependencies": {
-    "execa": "^0.8.0"
+    "execa": "^0.10.0"
   },
   "devDependencies": {
     "ava": "*",


### PR DESCRIPTION

As this is a dependency of [trash](https://github.com/sindresorhus/trash/). Upgrading would fix the following error:
```
Module not found: Error: Can't resolve 'spawn-sync' in '...node_modules/cross-spawn'
@ ./node_modules/cross-spawn/index.js
@ ./node_modules/run-applescript/node_modules/execa/index.js
@ ./node_modules/run-applescript/index.js
@ ./node_modules/trash/lib/macos.js
@ ./node_modules/trash/index.js
```

Similar to [this PR](https://github.com/sindresorhus/shell-env/pull/7)