### PR TITLE
feat: add support for output modifier flags

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -34,18 +34,11 @@ const result = await runAppleScript('return "unicorn"');
 console.log(result);
 //=> 'unicorn'
 ```
-
-@example
-```
-import {runAppleScript} from 'run-applescript';
-
-const result = await runAppleScript('return "unicorn"', {humanReadableOutput: false});
-
-console.log(result);
-//=> '"unicorn"'
-```
 */
-export function runAppleScript(script: string, options?: Options): Promise<string>;
+export function runAppleScript(
+	script: string,
+	options?: Options
+): Promise<string>;
 
 /**
 Run AppleScript synchronously.
@@ -62,16 +55,6 @@ const result = runAppleScriptSync('return "unicorn"');
 
 console.log(result);
 //=> 'unicorn'
-```
-
-@example
-```
-import {runAppleScript} from 'run-applescript';
-
-const result = await runAppleScript('return "unicorn"', {humanReadableOutput: false});
-
-console.log(result);
-//=> '"unicorn"'
 ```
 */
 export function runAppleScriptSync(script: string, options?: Options): string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,8 +2,18 @@ export type Options = {
 	/**
 	Modifies the output style.
 	If false returns value in recompilable source form.
+	Check {@link https://ss64.com/osx/osascript.html|Osascript's man age} for more information.
 
 	@default true
+	@example
+	```
+	import {runAppleScript} from 'run-applescript';
+
+	const result = await runAppleScript('return "unicorn"', {humanReadableOutput: false});
+
+	console.log(result);
+	//=> '"unicorn"'
+	```
 	*/
 	readonly humanReadableOutput?: boolean;
 };
@@ -29,10 +39,7 @@ console.log(result);
 ```
 import {runAppleScript} from 'run-applescript';
 
-const options = {
-    humanReadableOutput: false
-}
-const result = await runAppleScript('return "unicorn"', options);
+const result = await runAppleScript('return "unicorn"', {humanReadableOutput: false});
 
 console.log(result);
 //=> '"unicorn"'
@@ -61,10 +68,7 @@ console.log(result);
 ```
 import {runAppleScript} from 'run-applescript';
 
-const options = {
-    humanReadableOutput: false
-}
-const result = await runAppleScript('return "unicorn"', options);
+const result = await runAppleScript('return "unicorn"', {humanReadableOutput: false});
 
 console.log(result);
 //=> '"unicorn"'

--- a/index.d.ts
+++ b/index.d.ts
@@ -44,7 +44,6 @@ export function runAppleScript(
 Run AppleScript synchronously.
 
 @param script - The script to run.
-@param options - Options used when running the script.
 @returns The script result.
 
 @example

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,18 @@
+export type Options = {
+	/**
+	Modifies the output style.
+	If false returns value in recompilable source form.
+
+	@default true
+	*/
+	readonly humanReadableOutput?: boolean;
+};
+
 /**
 Run AppleScript asynchronously.
 
 @param script - The script to run.
-@param humanReadableOutput - Output modifier option (defaults to true).
+@param options - Options used when running the script.
 @returns The script result.
 
 @example
@@ -14,14 +24,27 @@ const result = await runAppleScript('return "unicorn"');
 console.log(result);
 //=> 'unicorn'
 ```
+
+@example
+```
+import {runAppleScript} from 'run-applescript';
+
+const options = {
+    humanReadableOutput: false
+}
+const result = await runAppleScript('return "unicorn"', options);
+
+console.log(result);
+//=> '"unicorn"'
+```
 */
-export function runAppleScript(script: string, humanReadableOutput?: boolean): Promise<string>;
+export function runAppleScript(script: string, options?: Options): Promise<string>;
 
 /**
 Run AppleScript synchronously.
 
 @param script - The script to run.
-@param humanReadableOutput - Output modifier option (defaults to true).
+@param options - Options used when running the script.
 @returns The script result.
 
 @example
@@ -33,5 +56,18 @@ const result = runAppleScriptSync('return "unicorn"');
 console.log(result);
 //=> 'unicorn'
 ```
+
+@example
+```
+import {runAppleScript} from 'run-applescript';
+
+const options = {
+    humanReadableOutput: false
+}
+const result = await runAppleScript('return "unicorn"', options);
+
+console.log(result);
+//=> '"unicorn"'
+```
 */
-export function runAppleScriptSync(script: string, humanReadableOutput?: boolean): string;
+export function runAppleScriptSync(script: string, options?: Options): string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@
 Run AppleScript asynchronously.
 
 @param script - The script to run.
-@param flags - Output modifier flags.
+@param humanReadableOutput - Output modifier option (defaults to true).
 @returns The script result.
 
 @example
@@ -15,13 +15,13 @@ console.log(result);
 //=> 'unicorn'
 ```
 */
-export function runAppleScript(script: string, flags?: string): Promise<string>;
+export function runAppleScript(script: string, humanReadableOutput?: boolean): Promise<string>;
 
 /**
 Run AppleScript synchronously.
 
 @param script - The script to run.
-@param flags - Output modifier flags.
+@param humanReadableOutput - Output modifier option (defaults to true).
 @returns The script result.
 
 @example
@@ -34,4 +34,4 @@ console.log(result);
 //=> 'unicorn'
 ```
 */
-export function runAppleScriptSync(script: string, flags?: string): string;
+export function runAppleScriptSync(script: string, humanReadableOutput?: boolean): string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,7 @@
 Run AppleScript asynchronously.
 
 @param script - The script to run.
+@param flags - Output modifier flags.
 @returns The script result.
 
 @example
@@ -14,12 +15,13 @@ console.log(result);
 //=> 'unicorn'
 ```
 */
-export function runAppleScript(script: string): Promise<string>;
+export function runAppleScript(script: string, flags?: string): Promise<string>;
 
 /**
 Run AppleScript synchronously.
 
 @param script - The script to run.
+@param flags - Output modifier flags.
 @returns The script result.
 
 @example
@@ -32,4 +34,4 @@ console.log(result);
 //=> 'unicorn'
 ```
 */
-export function runAppleScriptSync(script: string): string;
+export function runAppleScriptSync(script: string, flags?: string): string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,11 @@
 export type Options = {
 	/**
-	Modifies the output style.
-	If false returns value in recompilable source form.
-	Check {@link https://ss64.com/osx/osascript.html|Osascript's man age} for more information.
+	Change the output style.
+
+	When `false`, returns the value in a [recompilable source form](https://ss64.com/osx/osascript.html).
 
 	@default true
+
 	@example
 	```
 	import {runAppleScript} from 'run-applescript';
@@ -22,7 +23,6 @@ export type Options = {
 Run AppleScript asynchronously.
 
 @param script - The script to run.
-@param options - Options used when running the script.
 @returns The script result.
 
 @example

--- a/index.js
+++ b/index.js
@@ -1,20 +1,20 @@
 import process from 'node:process';
 import execa from 'execa';
 
-export async function runAppleScript(script) {
+export async function runAppleScript(script, flags = '') {
 	if (process.platform !== 'darwin') {
 		throw new Error('macOS only');
 	}
 
-	const {stdout} = await execa('osascript', ['-e', script]);
+	const {stdout} = await execa('osascript', ['-e', script, '-s', flags]);
 	return stdout;
 }
 
-export function runAppleScriptSync(script) {
+export function runAppleScriptSync(script, flags = '') {
 	if (process.platform !== 'darwin') {
 		throw new Error('macOS only');
 	}
 
-	const {stdout} = execa.sync('osascript', ['-e', script]);
+	const {stdout} = execa.sync('osascript', ['-e', script, '-s', flags]);
 	return stdout;
 }

--- a/index.js
+++ b/index.js
@@ -1,24 +1,28 @@
 import process from 'node:process';
 import execa from 'execa';
 
-export async function runAppleScript(script, humanReadableOutput = true) {
+const DEFAULT_OPTIONS = {
+	humanReadableOutput: true,
+};
+
+export async function runAppleScript(script, options = DEFAULT_OPTIONS) {
 	if (process.platform !== 'darwin') {
 		throw new Error('macOS only');
 	}
 
-	const humanReadableFlag = humanReadableOutput ? [] : ['-ss'];
+	const outputArg = options.humanReadableOutput ? [] : ['-ss'];
 
-	const {stdout} = await execa('osascript', ['-e', script, ...humanReadableFlag]);
+	const {stdout} = await execa('osascript', ['-e', script, outputArg]);
 	return stdout;
 }
 
-export function runAppleScriptSync(script, humanReadableOutput = true) {
+export function runAppleScriptSync(script, options = DEFAULT_OPTIONS) {
 	if (process.platform !== 'darwin') {
 		throw new Error('macOS only');
 	}
 
-	const humanReadableFlag = humanReadableOutput ? [] : ['-ss'];
+	const outputArg = options.humanReadableOutput ? [] : ['-ss'];
 
-	const {stdout} = execa.sync('osascript', ['-e', script, ...humanReadableFlag]);
+	const {stdout} = execa.sync('osascript', ['-e', script, ...outputArg]);
 	return stdout;
 }

--- a/index.js
+++ b/index.js
@@ -1,20 +1,24 @@
 import process from 'node:process';
 import execa from 'execa';
 
-export async function runAppleScript(script, flags = '') {
+export async function runAppleScript(script, humanReadableOutput = true) {
 	if (process.platform !== 'darwin') {
 		throw new Error('macOS only');
 	}
 
-	const {stdout} = await execa('osascript', ['-e', script, '-s', flags]);
+	const humanReadableFlag = humanReadableOutput ? [] : ['-ss'];
+
+	const {stdout} = await execa('osascript', ['-e', script, ...humanReadableFlag]);
 	return stdout;
 }
 
-export function runAppleScriptSync(script, flags = '') {
+export function runAppleScriptSync(script, humanReadableOutput = true) {
 	if (process.platform !== 'darwin') {
 		throw new Error('macOS only');
 	}
 
-	const {stdout} = execa.sync('osascript', ['-e', script, '-s', flags]);
+	const humanReadableFlag = humanReadableOutput ? [] : ['-ss'];
+
+	const {stdout} = execa.sync('osascript', ['-e', script, ...humanReadableFlag]);
 	return stdout;
 }

--- a/index.js
+++ b/index.js
@@ -1,28 +1,24 @@
 import process from 'node:process';
 import execa from 'execa';
 
-const DEFAULT_OPTIONS = {
-	humanReadableOutput: true,
-};
-
-export async function runAppleScript(script, options = DEFAULT_OPTIONS) {
+export async function runAppleScript(script, {humanReadableOutput = true} = {}) {
 	if (process.platform !== 'darwin') {
 		throw new Error('macOS only');
 	}
 
-	const outputArg = options.humanReadableOutput ? [] : ['-ss'];
+	const outputArguments = humanReadableOutput ? [] : ['-ss'];
 
-	const {stdout} = await execa('osascript', ['-e', script, outputArg]);
+	const {stdout} = await execa('osascript', ['-e', script, outputArguments]);
 	return stdout;
 }
 
-export function runAppleScriptSync(script, options = DEFAULT_OPTIONS) {
+export function runAppleScriptSync(script, {humanReadableOutput = true} = {}) {
 	if (process.platform !== 'darwin') {
 		throw new Error('macOS only');
 	}
 
-	const outputArg = options.humanReadableOutput ? [] : ['-ss'];
+	const outputArguments = humanReadableOutput ? [] : ['-ss'];
 
-	const {stdout} = execa.sync('osascript', ['-e', script, ...outputArg]);
+	const {stdout} = execa.sync('osascript', ['-e', script, ...outputArguments]);
 	return stdout;
 }

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -3,5 +3,5 @@ import {runAppleScript, runAppleScriptSync} from './index.js';
 
 expectType<Promise<string>>(runAppleScript('return "unicorn"'));
 expectType<string>(runAppleScriptSync('return "unicorn"'));
-expectType<Promise<string>>(runAppleScript('return {"unicorn"}', false));
-expectType<string>(runAppleScriptSync('return {"unicorn"}', false));
+expectType<Promise<string>>(runAppleScript('return {"unicorn"}', {humanReadableOutput: false}));
+expectType<string>(runAppleScriptSync('return {"unicorn"}', {humanReadableOutput: false}));

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -3,5 +3,5 @@ import {runAppleScript, runAppleScriptSync} from './index.js';
 
 expectType<Promise<string>>(runAppleScript('return "unicorn"'));
 expectType<string>(runAppleScriptSync('return "unicorn"'));
-expectType<Promise<string>>(runAppleScript('return {"unicorn"}', 's'));
-expectType<string>(runAppleScriptSync('return {"unicorn"}', 's'));
+expectType<Promise<string>>(runAppleScript('return {"unicorn"}', false));
+expectType<string>(runAppleScriptSync('return {"unicorn"}', false));

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -3,3 +3,5 @@ import {runAppleScript, runAppleScriptSync} from './index.js';
 
 expectType<Promise<string>>(runAppleScript('return "unicorn"'));
 expectType<string>(runAppleScriptSync('return "unicorn"'));
+expectType<Promise<string>>(runAppleScript('return {"unicorn"}', 's'));
+expectType<string>(runAppleScriptSync('return {"unicorn"}', 's'));

--- a/readme.md
+++ b/readme.md
@@ -21,13 +21,51 @@ console.log(result);
 
 ## API
 
-### runAppleScript(script)
+### runAppleScript(script, options?)
 
 Returns a `Promise<string>` with the script result.
 
-### runAppleScriptSync(script)
+#### script
+
+Type: `string`
+
+The script to run.
+
+#### options
+
+Type: `object`
+
+##### humanReadableOutput
+
+Type: `boolean`\
+Default: `true`
+
+Change the output style.
+
+When `false`, returns the value in a [recompilable source form](https://ss64.com/osx/osascript.html).
+
+### runAppleScriptSync(script, options?)
 
 Returns a `string` with the script result.
+
+#### script
+
+Type: `string`
+
+The script to run.
+
+#### options
+
+Type: `object`
+
+##### humanReadableOutput
+
+Type: `boolean`\
+Default: `true`
+
+Change the output style.
+
+When `false`, returns the value in a [recompilable source form](https://ss64.com/osx/osascript.html).
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -8,3 +8,11 @@ test('async', async t => {
 test('sync', t => {
 	t.is(runAppleScriptSync('return "unicorn"'), 'unicorn');
 });
+
+test('output flags async', async t => {
+	t.is(await runAppleScript('return {"unicorn"}', 's'), '{"unicorn"}');
+});
+
+test('output flags sync', t => {
+	t.is(runAppleScriptSync('return {"unicorn"}', 's'), '{"unicorn"}');
+});

--- a/test.js
+++ b/test.js
@@ -9,18 +9,18 @@ test('sync', t => {
 	t.is(runAppleScriptSync('return "unicorn"'), 'unicorn');
 });
 
-test('non human readable output async', async t => {
+test('non-human readable output - async', async t => {
 	t.is(await runAppleScript('return "unicorn"', {humanReadableOutput: false}), '"unicorn"');
 });
 
-test('non human readable output sync', t => {
+test('non-human readable output - sync', t => {
 	t.is(runAppleScriptSync('return "unicorn"', {humanReadableOutput: false}), '"unicorn"');
 });
 
-test('non human readable output (arrays) async', async t => {
+test('non-human readable output (arrays) - async', async t => {
 	t.is(await runAppleScript('return {"unicorn"}', {humanReadableOutput: false}), '{"unicorn"}');
 });
 
-test('non human readable output (arrays) sync', t => {
+test('non-human readable output (arrays) - sync', t => {
 	t.is(runAppleScriptSync('return {"unicorn"}', {humanReadableOutput: false}), '{"unicorn"}');
 });

--- a/test.js
+++ b/test.js
@@ -9,18 +9,18 @@ test('sync', t => {
 	t.is(runAppleScriptSync('return "unicorn"'), 'unicorn');
 });
 
-test('non-human readable output - async', async t => {
+test('async - non-human readable output', async t => {
 	t.is(await runAppleScript('return "unicorn"', {humanReadableOutput: false}), '"unicorn"');
 });
 
-test('non-human readable output - sync', t => {
+test('sync - non-human readable output', t => {
 	t.is(runAppleScriptSync('return "unicorn"', {humanReadableOutput: false}), '"unicorn"');
 });
 
-test('non-human readable output (arrays) - async', async t => {
+test('async - non-human readable output (arrays)', async t => {
 	t.is(await runAppleScript('return {"unicorn"}', {humanReadableOutput: false}), '{"unicorn"}');
 });
 
-test('non-human readable output (arrays) - sync', t => {
+test('sync - non-human readable output (arrays)', t => {
 	t.is(runAppleScriptSync('return {"unicorn"}', {humanReadableOutput: false}), '{"unicorn"}');
 });

--- a/test.js
+++ b/test.js
@@ -9,10 +9,18 @@ test('sync', t => {
 	t.is(runAppleScriptSync('return "unicorn"'), 'unicorn');
 });
 
-test('output flags async', async t => {
-	t.is(await runAppleScript('return {"unicorn"}', false), '{"unicorn"}');
+test('non human readable output async', async t => {
+	t.is(await runAppleScript('return "unicorn"', {humanReadableOutput: false}), '"unicorn"');
 });
 
-test('output flags sync', t => {
-	t.is(runAppleScriptSync('return {"unicorn"}', false), '{"unicorn"}');
+test('non human readable output sync', t => {
+	t.is(runAppleScriptSync('return "unicorn"', {humanReadableOutput: false}), '"unicorn"');
+});
+
+test('non human readable output (arrays) async', async t => {
+	t.is(await runAppleScript('return {"unicorn"}', {humanReadableOutput: false}), '{"unicorn"}');
+});
+
+test('non human readable output (arrays) sync', t => {
+	t.is(runAppleScriptSync('return {"unicorn"}', {humanReadableOutput: false}), '{"unicorn"}');
 });

--- a/test.js
+++ b/test.js
@@ -10,9 +10,9 @@ test('sync', t => {
 });
 
 test('output flags async', async t => {
-	t.is(await runAppleScript('return {"unicorn"}', 's'), '{"unicorn"}');
+	t.is(await runAppleScript('return {"unicorn"}', false), '{"unicorn"}');
 });
 
 test('output flags sync', t => {
-	t.is(runAppleScriptSync('return {"unicorn"}', 's'), '{"unicorn"}');
+	t.is(runAppleScriptSync('return {"unicorn"}', false), '{"unicorn"}');
 });


### PR DESCRIPTION
Currently, only `-e` option is used to execute an inline script. 

This PR:
- Adds support for osascript's output modifier flags `-s` (as specified [here](https://ss64.com/osx/osascript.html)). 
- Adds tests to ensure current behaviour is kept and `-s` flag behaviour works

I'm not sure if this solves #4, but using the `-s s` flag, it returns a string that can be parsed into an array. Neverthless, I think it is useful to have this option available to mirror the behaviour of the `osascript` command,.

Output without `-s` flag:
```
$ osascript -e 'return {{"foo", {"bar"}}}'        
foo, bar
```

Output with `-s` flag:
```
$ osascript -e 'return {{"foo", {"bar"}}}'  -s s
{{"foo", {"bar"}}}
```